### PR TITLE
Very small regex pattern tweak to allow Still to process column names that contain spaces

### DIFF
--- a/src/schema/schema.go
+++ b/src/schema/schema.go
@@ -73,7 +73,7 @@ func parseColumn(line string) Col {
 
 		latitude: in_range(-90, 90) # The latitude
 	*/
-	reColumn, err := regexp.Compile("^([^: ]+):([^$#]+)?(#.*$)?")
+	reColumn, err := regexp.Compile("^([^:]+):([^$#]+)?(#.*$)?")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Hi Daniel,

I've been working with Still to validate normalization in a very large tabular database that has spaces in the column names. After working through a panic traceback, it seems like the problem stems solely from the regex pattern in line 82 of schema.go, which matches for any symbol except for ":" to split out the column name from the rule. After altering the pattern so that it splits by ": ", it appears to be working as expected in my tests. Since it's working for me, I figured I'd submit a PR!

Let me know if you have any other questions, and thanks very much for the tool! It has been a huge help to me and the lab I work in.

--Nick